### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Checkout library branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: "library"
           path: "library"


### PR DESCRIPTION
## Summary
- pin actions/checkout steps in update workflow to full-length commit SHA with version comment

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c60d2138832686c1dbff16acede0)